### PR TITLE
Remove noqa suppressions by fixing underlying linter warnings

### DIFF
--- a/pytimings/plotting/colors.py
+++ b/pytimings/plotting/colors.py
@@ -12,6 +12,10 @@ __all__ = [
     "get_hue_vector_rec",
 ]
 
+_SWITCH_COLOR_VALUE = 2
+_WCAG_LINEARIZE_THRESHOLD = 0.03928
+_MAX_CONTRAST_RATIO = 0.6
+
 
 def get_hue_vector(amount):
     level = 0
@@ -70,7 +74,7 @@ def get_colour_palette(size):
 
         if switccolors == 1:
             saturation = satvalsplittings[satvalbifurcatepos - 1]
-        elif switccolors == 2:  # noqa: PLR2004
+        elif switccolors == _SWITCH_COLOR_VALUE:
             value = satvalsplittings[satvalbifurcatepos - 1]
 
         hue += 0.17  # ; // use as starting point a zone where color band is narrow so that small variations means
@@ -88,7 +92,7 @@ def contrast_ratio(color_a, color_b):
 
     def _lum(c):
         c = float(c)
-        if c <= 0.03928:  # noqa: PLR2004
+        if c <= _WCAG_LINEARIZE_THRESHOLD:
             return c / 12.92
         return ((c + 0.055) / 1.055) ** 2.4
 
@@ -108,7 +112,7 @@ def get_colour_palette_cheat(size, filter_colors=None, bg_color=(1, 1, 1)):
         k = [
             p
             for p in set(get_colour_palette(candidate_size))
-            if p not in filter_colors and contrast_ratio(p, bg_color) < 0.6  # noqa: PLR2004
+            if p not in filter_colors and contrast_ratio(p, bg_color) < _MAX_CONTRAST_RATIO
         ]
         candidate_size += 1
         if candidate_size > max_size:

--- a/scripts/generate_speedup_data.py
+++ b/scripts/generate_speedup_data.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 
-import os
 import sys
+from pathlib import Path
 
 from pytimings.tools import generate_example_data
 
 try:
     output_dir = sys.argv[1]
 except IndexError:
-    output_dir = os.getcwd()  # noqa: PTH109
+    output_dir = Path.cwd()
 
 try:
     runs = sys.argv[2]

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -2,6 +2,7 @@ import matplotlib
 import pytest
 
 from pytimings.plotting.colors import (
+    _MAX_CONTRAST_RATIO,
     contrast_ratio,
     discrete_cmap,
     get_colour_palette,
@@ -41,8 +42,9 @@ def test_discrete_cmap_rejects_dark_bg_color():
 
 
 def test_get_colour_palette_cheat_creates_correct_number_of_colors():
-    palette = get_colour_palette_cheat(5)
-    assert len(palette) == 5  # noqa: PLR2004
+    count = 5
+    palette = get_colour_palette_cheat(count)
+    assert len(palette) == count
 
 
 def test_get_colour_palette_cheat_handles_zero_colors():
@@ -60,7 +62,7 @@ def test_get_colour_palette_cheat_excludes_filter_colors():
 def test_get_colour_palette_cheat_uses_default_bg_color():
     palette = get_colour_palette_cheat(3)
     for color in palette:
-        assert contrast_ratio(color, (1, 1, 1)) < 0.6  # noqa: PLR2004
+        assert contrast_ratio(color, (1, 1, 1)) < _MAX_CONTRAST_RATIO
 
 
 def test_get_colour_palette_cheat_rejects_dark_bg_color():
@@ -91,8 +93,9 @@ def test_contrast_ratio_handles_low_luminance():
 
 
 def test_get_colour_palette_creates_correct_number_of_colors():
-    palette = get_colour_palette(5)
-    assert len(palette) == 5  # noqa: PLR2004
+    count = 5
+    palette = get_colour_palette(count)
+    assert len(palette) == count
 
 
 def test_get_colour_palette_handles_zero_colors():

--- a/tests/test_example_data.py
+++ b/tests/test_example_data.py
@@ -5,23 +5,24 @@ from pytimings.tools import generate_example_data
 
 def test_generate_example_data_creates_correct_number_of_files():
     with (
-        patch("pytimings.timer.Timings") as MockTimings,  # noqa: N806
+        patch("pytimings.timer.Timings") as mock_timings_cls,
         patch("pytimings.timer.scoped_timing"),
         patch("pytimings.tools.busywait"),
     ):
-        mock_timings = MockTimings.return_value
+        mock_timings = mock_timings_cls.return_value
         mock_timings.output_files.return_value = "mock_file"
-        files = generate_example_data("mock_output_dir", number_of_runs=5)
-        assert len(files) == 4  # noqa: PLR2004
+        number_of_runs = 5
+        files = generate_example_data("mock_output_dir", number_of_runs=number_of_runs)
+        assert len(files) == number_of_runs - 1
 
 
 def test_generate_example_data_handles_zero_runs():
     with (
-        patch("pytimings.timer.Timings") as MockTimings,  # noqa: N806
+        patch("pytimings.timer.Timings") as mock_timings_cls,
         patch("pytimings.timer.scoped_timing"),
         patch("pytimings.tools.busywait"),
     ):
-        mock_timings = MockTimings.return_value
+        mock_timings = mock_timings_cls.return_value
         mock_timings.output_files.return_value = "mock_file"
         files = generate_example_data("mock_output_dir", number_of_runs=0)
         assert len(files) == 0
@@ -29,11 +30,11 @@ def test_generate_example_data_handles_zero_runs():
 
 def test_generate_example_data_creates_files_with_correct_names():
     with (
-        patch("pytimings.timer.Timings") as MockTimings,  # noqa: N806
+        patch("pytimings.timer.Timings") as mock_timings_cls,
         patch("pytimings.timer.scoped_timing"),
         patch("pytimings.tools.busywait"),
     ):
-        mock_timings = MockTimings.return_value
+        mock_timings = mock_timings_cls.return_value
         mock_timings.output_files.side_effect = lambda output_dir, csv_base: f"{csv_base}.csv"
         files = generate_example_data("mock_output_dir", number_of_runs=3)
         assert files == ["example_speedup_00001.csv", "example_speedup_00002.csv"]
@@ -41,11 +42,12 @@ def test_generate_example_data_creates_files_with_correct_names():
 
 def test_generate_example_data_handles_large_number_of_runs():
     with (
-        patch("pytimings.timer.Timings") as MockTimings,  # noqa: N806
+        patch("pytimings.timer.Timings") as mock_timings_cls,
         patch("pytimings.timer.scoped_timing"),
         patch("pytimings.tools.busywait"),
     ):
-        mock_timings = MockTimings.return_value
+        mock_timings = mock_timings_cls.return_value
         mock_timings.output_files.return_value = "mock_file"
-        files = generate_example_data("mock_output_dir", number_of_runs=100)
-        assert len(files) == 99  # noqa: PLR2004
+        number_of_runs = 100
+        files = generate_example_data("mock_output_dir", number_of_runs=number_of_runs)
+        assert len(files) == number_of_runs - 1

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -32,7 +32,7 @@ def test_output_per_rank(pickled_timings_object, file_regression, tmp_path):
 
     if fn is not None:
         # we're rank 0 and have written the summary file
-        file_regression.check(_content(open(fn)))  # noqa: PTH123
+        file_regression.check(_content(fn.open()))
 
 
 def test_csv_to_dataframe(tmpdir):


### PR DESCRIPTION
## Summary

- **PTH109**: Replace `os.getcwd()` with `Path.cwd()` in `scripts/generate_speedup_data.py`, removing the now-unused `import os`
- **PTH123**: Replace bare `open(fn)` with `fn.open()` in `tests/test_output.py`
- **N806** (4×): Rename `MockTimings` → `mock_timings_cls` in `tests/test_example_data.py` to satisfy snake_case naming
- **PLR2004** (7×): Replace magic literals with named constants (`_WCAG_LINEARIZE_THRESHOLD`, `_MAX_CONTRAST_RATIO`, `_SWITCH_COLOR_VALUE`) in `pytimings/plotting/colors.py`, and with local variables or derived expressions in the test files
- **E402** in `docs/conf.py`: Kept as-is — the import must follow `sys.path.insert(...)` per standard Sphinx convention

## Test plan

- [ ] `ruff check .` reports no warnings
- [ ] `pytest tests/` — 41 tests pass (2 pre-existing failures due to missing optional deps: `pandas`, `rich`)

https://claude.ai/code/session_01TwD78Laos4qqM5UbeX13yY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwD78Laos4qqM5UbeX13yY)_